### PR TITLE
slack e2e: direct-token auth isolation, assistant greetings, never-silent ack

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1534,6 +1534,61 @@ def _is_slack_ignored_channel(config: Any, chat_id: Any) -> bool:
     return bool(channel_id and ("*" in ignored or channel_id in ignored))
 
 
+def _event_addressed_bot(event: Any, source: Any) -> bool:
+    """Return whether the inbound event was a direct address to the bot.
+
+    Adapters that distinguish direct addresses from passive traffic (Slack:
+    1:1 DMs, @mentions, replies inside bot-participated threads) mark the
+    event with ``metadata["addressed_bot"]``.  When no mark exists, DMs count
+    as direct addresses and group messages do not — the conservative fallback
+    that keeps passive free-response ingestion eligible for intentional
+    silence.
+    """
+    metadata = getattr(event, "metadata", None) or {}
+    if "addressed_bot" in metadata:
+        return bool(metadata["addressed_bot"])
+    return getattr(source, "chat_type", "") == "dm"
+
+
+def _never_silent_ack_enabled(user_config: Optional[dict]) -> bool:
+    """Whether a directly-addressed turn may never end in total silence.
+
+    ``gateway.never_silent_ack: false`` in config.yaml opts out and restores
+    the legacy behavior where the agent's NO_REPLY/[SILENT] marker suppresses
+    all outbound text even when the user directly addressed the bot.
+    """
+    try:
+        gateway_cfg = (user_config or {}).get("gateway") or {}
+        raw = gateway_cfg.get("never_silent_ack", True)
+    except Exception:
+        return True
+    if isinstance(raw, str):
+        return raw.strip().lower() not in {"0", "false", "no", "off"}
+    return bool(raw)
+
+
+_NEVER_SILENT_ACK_TEXT = "✓ Received."
+
+
+def _never_silent_ack_response(event: Any, source: Any, user_config: Optional[dict]) -> str:
+    """Resolve the outbound text for an intentional-silence turn.
+
+    The NO_REPLY/[SILENT] marker governs passive free-response ingestion: it
+    suppresses all outbound text there (returns ``""``).  A turn the user
+    directly addressed — DM, @mention, or reply in a bot thread — must never
+    end in total silence, so the marker is replaced with a minimal visible
+    ack instead.  Synthetic internal events (background notifications) keep
+    the suppression path either way.
+    """
+    if (
+        not getattr(event, "internal", False)
+        and _never_silent_ack_enabled(user_config)
+        and _event_addressed_bot(event, source)
+    ):
+        return _NEVER_SILENT_ACK_TEXT
+    return ""
+
+
 def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
     """True when gateway.message_timestamps.enabled is opted in.
 
@@ -20964,11 +21019,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # user/assistant alternation; only the outbound chat delivery is
             # suppressed.
             if _intentional_silence:
-                logger.info(
-                    "Suppressing intentional silence marker for session %s",
-                    session_entry.session_id,
+                # Never-silent ack (gateway behavior): a turn the user
+                # directly addressed (DM, @mention, reply in a bot thread)
+                # must always leave a visible trace in the chat.  The
+                # NO_REPLY/[SILENT] marker governs passive free-response
+                # ingestion only; for direct addresses it is replaced with a
+                # minimal ack instead of leaving the user on read.
+                response = _never_silent_ack_response(
+                    event, source, _load_gateway_config(),
                 )
-                response = ""
+                if response:
+                    logger.info(
+                        "Never-silent ack: replacing intentional silence with "
+                        "a visible ack for session %s",
+                        session_entry.session_id,
+                    )
+                else:
+                    logger.info(
+                        "Suppressing intentional silence marker for session %s",
+                        session_entry.session_id,
+                    )
 
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1056,6 +1056,7 @@ class SlackAdapter(BasePlatformAdapter):
         # Best-effort guard so automatic Slack AI thread titles are set once
         # per visible DM thread instead of on every reply.
         self._titled_assistant_threads: set = set()
+        self._greeted_assistant_threads: set = set()
         self._TITLED_ASSISTANT_THREADS_MAX = 5000
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
@@ -5239,6 +5240,38 @@ class SlackAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
 
+    async def _greet_assistant_thread(self, metadata: Dict[str, str]) -> None:
+        """Send one configured welcome message for a newly created Assistant thread."""
+        if not self._app:
+            return
+        greeting = str(self.config.extra.get("assistant_thread_greeting") or "").strip()
+        channel_id = metadata.get("channel_id", "")
+        thread_ts = metadata.get("thread_ts", "")
+        team_id = metadata.get("team_id", "")
+        key = self._workspace_thread_key(team_id, channel_id, thread_ts)
+        if not greeting or not key or key in self._greeted_assistant_threads:
+            return
+
+        try:
+            await self._get_client(channel_id, team_id=team_id).chat_postMessage(
+                channel=channel_id,
+                thread_ts=thread_ts,
+                text=greeting[:3000],
+            )
+        except Exception as e:
+            logger.debug("[Slack] assistant thread greeting failed: %s", e)
+            return
+
+        self._greeted_assistant_threads.add(key)
+        if len(self._greeted_assistant_threads) > self._TITLED_ASSISTANT_THREADS_MAX:
+            excess = (
+                len(self._greeted_assistant_threads)
+                - self._TITLED_ASSISTANT_THREADS_MAX // 2
+            )
+            self._discard_oldest_by_thread_ts(
+                self._greeted_assistant_threads, excess, lambda entry: entry[2]
+            )
+
     async def _handle_assistant_thread_lifecycle_event(
         self, event: dict, body: Optional[dict] = None
     ) -> None:
@@ -5246,6 +5279,8 @@ class SlackAdapter(BasePlatformAdapter):
         metadata = self._extract_assistant_thread_metadata(event, body)
         self._cache_assistant_thread_metadata(metadata)
         self._seed_assistant_thread_session(metadata)
+        if event.get("type") == "assistant_thread_started":
+            await self._greet_assistant_thread(metadata)
         await self._set_assistant_suggested_prompts(
             metadata.get("channel_id", ""),
             team_id=metadata.get("team_id", ""),

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -23,6 +23,7 @@ from typing import Callable, ClassVar, Dict, Optional, Any, Tuple, List
 import aiohttp
 
 try:
+    from slack_bolt.authorization import AuthorizeResult
     from slack_bolt.async_app import AsyncApp
     from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
     from slack_sdk.web.async_client import AsyncWebClient
@@ -30,6 +31,7 @@ try:
     SLACK_AVAILABLE = True
 except ImportError:
     SLACK_AVAILABLE = False
+    AuthorizeResult = Any
     AsyncApp = Any
     AsyncSocketModeHandler = Any
     AsyncWebClient = Any
@@ -1091,6 +1093,36 @@ class SlackAdapter(BasePlatformAdapter):
         # first ping/pong as evidence of a wedged transport.
         self._socket_first_ping_grace_s = 60.0
 
+    async def _authorize_slack_request(
+        self,
+        enterprise_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+    ) -> Optional[Any]:
+        """Authorize a Bolt request from Hermes's resolved workspace clients.
+
+        Passing an explicit callback prevents ambient Slack OAuth client
+        credentials from replacing Hermes's direct bot-token authorization
+        with Bolt's unrelated installation store. The callback also keeps the
+        request client workspace-correct for multi-workspace Socket Mode.
+        """
+        selected_team_id = str(team_id or "")
+        client = self._team_clients.get(selected_team_id)
+        if client is None and not selected_team_id and len(self._team_clients) == 1:
+            selected_team_id, client = next(iter(self._team_clients.items()))
+        if client is None:
+            logger.error(
+                "[Slack] Cannot authorize event for unknown workspace %s",
+                selected_team_id or "(missing)",
+            )
+            return None
+
+        return AuthorizeResult(
+            enterprise_id=enterprise_id,
+            team_id=selected_team_id or team_id,
+            bot_token=getattr(client, "token", None),
+            bot_user_id=self._team_bot_user_ids.get(selected_team_id),
+        )
+
     async def _close_workspace_clients(self) -> None:
         """Close any Slack SDK clients that may own aiohttp sessions."""
         clients: List[Any] = []
@@ -1955,7 +1987,20 @@ class SlackAdapter(BasePlatformAdapter):
                 token=primary_token,
                 user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
             )
-            self._app = AsyncApp(token=primary_token, client=primary_client)
+            async def authorize_slack_request(
+                enterprise_id: Optional[str] = None,
+                team_id: Optional[str] = None,
+            ) -> Optional[Any]:
+                return await self._authorize_slack_request(
+                    enterprise_id=enterprise_id,
+                    team_id=team_id,
+                )
+
+            self._app = AsyncApp(
+                token=primary_token,
+                client=primary_client,
+                authorize=authorize_slack_request,  # type: ignore[arg-type]
+            )
             _apply_slack_proxy(self._app.client, proxy_url)
 
             # Register each bot token and map team_id → client

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6877,6 +6877,19 @@ class SlackAdapter(BasePlatformAdapter):
             text, chat_id=channel_id, team_id=team_id
         )
 
+        # Mark direct addresses for the gateway's never-silent ack: 1:1 DMs,
+        # @mentions, and replies inside a thread the bot participates in are
+        # user-initiated conversations where a completed turn must never end
+        # in total silence.  Passive free-response channel traffic is left
+        # unmarked so intentional silence stays available there.
+        _addressed_bot = bool(
+            is_one_to_one_dm
+            or is_mentioned
+            or (
+                is_thread_reply
+                and event_thread_ts in self._bot_message_ts
+            )
+        )
         msg_event = MessageEvent(
             text=(command_probe_text if is_command_text else text),
             message_type=msg_type,
@@ -6894,6 +6907,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "slack_team_id": team_id,
                 "slack_channel_id": channel_id,
                 "slack_thread_ts": thread_ts,
+                "addressed_bot": _addressed_bot,
             },
         )
 

--- a/tests/gateway/test_gateway_silence_tokens.py
+++ b/tests/gateway/test_gateway_silence_tokens.py
@@ -165,6 +165,21 @@ async def test_prose_mentioning_silence_token_is_delivered(monkeypatch, tmp_path
     assert response == text
 
 
+def _silent_agent_result():
+    return {
+        "final_response": "[SILENT]",
+        "messages": [
+            {"role": "user", "content": "side chatter"},
+            {"role": "assistant", "content": "[SILENT]"},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": False,
+    }
+
+
 @pytest.mark.asyncio
 async def test_agent_end_hook_includes_model_and_provider(monkeypatch, tmp_path):
     """Gateway hooks receive the actual model/provider for post-turn routing."""
@@ -195,3 +210,56 @@ async def test_agent_end_hook_includes_model_and_provider(monkeypatch, tmp_path)
     )
     assert end_context["model"] == "gpt-5.6-terra"
     assert end_context["provider"] == "openai-codex"
+
+
+@pytest.mark.asyncio
+async def test_directly_addressed_silence_gets_never_silent_ack(monkeypatch, tmp_path):
+    """A direct address must never end in total silence: the gateway replaces
+    the intentional-silence marker with a minimal visible ack."""
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(return_value=_silent_agent_result())
+
+    event = _event()
+    event.metadata["addressed_bot"] = True
+    response = await runner._handle_message_with_agent(
+        event, _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response == "✓ Received."
+    # The ack replaces delivery text only — the [SILENT] assistant turn is
+    # still persisted so alternation is preserved.
+    appended = [call.args[1] for call in runner.session_store.append_to_transcript.call_args_list]
+    assert {"role": "assistant", "content": "[SILENT]"}.items() <= appended[-1].items()
+
+
+@pytest.mark.asyncio
+async def test_explicitly_passive_silence_stays_silent(monkeypatch, tmp_path):
+    """Free-response passive traffic keeps the intentional-silence path even
+    with the ack enabled (adapter marked the event as not addressed)."""
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(return_value=_silent_agent_result())
+
+    event = _event()
+    event.metadata["addressed_bot"] = False
+    response = await runner._handle_message_with_agent(
+        event, _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response == ""
+
+
+@pytest.mark.asyncio
+async def test_never_silent_ack_config_opt_out(monkeypatch, tmp_path):
+    """gateway.never_silent_ack: false restores legacy silence even for a
+    direct address."""
+    (tmp_path / "config.yaml").write_text("gateway:\n  never_silent_ack: false\n")
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(return_value=_silent_agent_result())
+
+    event = _event()
+    event.metadata["addressed_bot"] = True
+    response = await runner._handle_message_with_agent(
+        event, _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response == ""

--- a/tests/gateway/test_never_silent_ack.py
+++ b/tests/gateway/test_never_silent_ack.py
@@ -1,0 +1,208 @@
+"""Never-silent ack: directly-addressed turns must never end in total silence.
+
+Covers the three pieces of the contract:
+
+* ``gateway.run._never_silent_ack_response`` — the intentional-silence marker
+  (NO_REPLY/[SILENT]) is replaced with a minimal visible ack when the user
+  directly addressed the bot, and keeps suppressing outbound text for
+  passive free-response ingestion.
+* ``gateway.run._event_addressed_bot`` / ``_never_silent_ack_enabled`` —
+  direct-address resolution and the config opt-out.
+* Slack adapter inbound marking — ``metadata["addressed_bot"]`` is set on
+  1:1 DMs, @mentions, and bot-thread replies, and left False for passive
+  free-response channel traffic.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.run import (
+    _NEVER_SILENT_ACK_TEXT,
+    _event_addressed_bot,
+    _never_silent_ack_enabled,
+    _never_silent_ack_response,
+)
+
+
+def _event(metadata=None, internal=False):
+    return SimpleNamespace(metadata=metadata or {}, internal=internal)
+
+
+def _source(chat_type="group"):
+    return SimpleNamespace(chat_type=chat_type)
+
+
+class TestEventAddressedBot:
+    def test_metadata_true_marks_direct_address(self):
+        assert _event_addressed_bot(_event({"addressed_bot": True}), _source()) is True
+
+    def test_metadata_false_marks_passive(self):
+        assert _event_addressed_bot(_event({"addressed_bot": False}), _source()) is False
+
+    def test_unmarked_dm_counts_as_direct_address(self):
+        assert _event_addressed_bot(_event(), _source("dm")) is True
+
+    def test_unmarked_group_does_not_count(self):
+        # Conservative fallback: platforms that never mark the event keep
+        # intentional silence available in group channels.
+        assert _event_addressed_bot(_event(), _source("group")) is False
+
+    def test_missing_metadata_attr_is_safe(self):
+        assert _event_addressed_bot(SimpleNamespace(), _source("group")) is False
+
+
+class TestNeverSilentAckEnabled:
+    def test_default_is_enabled(self):
+        assert _never_silent_ack_enabled({}) is True
+        assert _never_silent_ack_enabled(None) is True
+        assert _never_silent_ack_enabled({"gateway": {}}) is True
+
+    def test_config_opt_out(self):
+        assert _never_silent_ack_enabled({"gateway": {"never_silent_ack": False}}) is False
+
+    @pytest.mark.parametrize("raw", ["false", "0", "no", "off", "False", " OFF "])
+    def test_string_opt_outs(self, raw):
+        assert _never_silent_ack_enabled({"gateway": {"never_silent_ack": raw}}) is False
+
+    @pytest.mark.parametrize("raw", ["true", "1", "yes", "on"])
+    def test_string_opt_ins(self, raw):
+        assert _never_silent_ack_enabled({"gateway": {"never_silent_ack": raw}}) is True
+
+    def test_malformed_config_stays_enabled(self):
+        assert _never_silent_ack_enabled({"gateway": None}) is True
+
+
+class TestNeverSilentAckResponse:
+    def test_direct_address_gets_visible_ack(self):
+        out = _never_silent_ack_response(
+            _event({"addressed_bot": True}), _source(), {},
+        )
+        assert out == _NEVER_SILENT_ACK_TEXT
+        assert out.strip()  # never empty for a direct address
+
+    def test_passive_free_response_stays_silent(self):
+        assert _never_silent_ack_response(
+            _event({"addressed_bot": False}), _source(), {},
+        ) == ""
+
+    def test_config_opt_out_restores_legacy_silence(self):
+        cfg = {"gateway": {"never_silent_ack": False}}
+        assert _never_silent_ack_response(
+            _event({"addressed_bot": True}), _source(), cfg,
+        ) == ""
+
+    def test_internal_synthetic_event_never_acked(self):
+        # Background-process notifications and other synthetic turns are not
+        # user addresses; an ack would surface as unprompted channel noise.
+        assert _never_silent_ack_response(
+            _event({"addressed_bot": True}, internal=True), _source(), {},
+        ) == ""
+
+
+# ---------------------------------------------------------------------------
+# Slack adapter inbound marking
+# ---------------------------------------------------------------------------
+
+
+def _make_slack_adapter():
+    from gateway.config import PlatformConfig
+    from plugins.platforms.slack.adapter import SlackAdapter
+
+    config = PlatformConfig(enabled=True, token="***")
+    adapter = SlackAdapter(config)
+    adapter._app = MagicMock()
+    adapter._app.client = AsyncMock()
+    adapter._app.client.users_info = AsyncMock(
+        return_value={
+            "user": {
+                "is_bot": False,
+                "profile": {"display_name": "Test User"},
+                "real_name": "Test User",
+            }
+        }
+    )
+    adapter._bot_user_id = "U_BOT"
+    adapter._team_bot_user_ids = {"T_TEAM": "U_BOT"}
+    adapter._running = True
+    adapter.handle_message = AsyncMock()
+    store = MagicMock()
+    store.get_or_create_session.return_value = SimpleNamespace(session_id="s1")
+    adapter.set_session_store(store)
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_slack_mention_marks_addressed_bot():
+    adapter = _make_slack_adapter()
+    await adapter._handle_slack_message(
+        {
+            "text": "<@U_BOT> ping",
+            "channel": "C_CHAN",
+            "channel_type": "channel",
+            "ts": "171.111",
+            "user": "U_USER",
+            "team_id": "T_TEAM",
+        }
+    )
+
+    msg_event = adapter.handle_message.await_args.args[0]
+    assert msg_event.metadata["addressed_bot"] is True
+
+
+@pytest.mark.asyncio
+async def test_slack_one_to_one_dm_marks_addressed_bot():
+    adapter = _make_slack_adapter()
+    await adapter._handle_slack_message(
+        {
+            "text": "hello",
+            "channel": "D123",
+            "channel_type": "im",
+            "ts": "171.222",
+            "user": "U_USER",
+            "team_id": "T_TEAM",
+        }
+    )
+
+    msg_event = adapter.handle_message.await_args.args[0]
+    assert msg_event.metadata["addressed_bot"] is True
+
+
+@pytest.mark.asyncio
+async def test_slack_bot_thread_reply_marks_addressed_bot():
+    adapter = _make_slack_adapter()
+    adapter._bot_message_ts.add("171.000")  # bot's earlier reply in this thread
+    await adapter._handle_slack_message(
+        {
+            "text": "following up",
+            "channel": "C_CHAN",
+            "channel_type": "channel",
+            "ts": "171.333",
+            "thread_ts": "171.000",
+            "user": "U_USER",
+            "team_id": "T_TEAM",
+        }
+    )
+
+    msg_event = adapter.handle_message.await_args.args[0]
+    assert msg_event.metadata["addressed_bot"] is True
+
+
+@pytest.mark.asyncio
+async def test_slack_free_response_passive_message_not_marked():
+    adapter = _make_slack_adapter()
+    adapter.config.extra["free_response_channels"] = ["C_CHAN"]
+    await adapter._handle_slack_message(
+        {
+            "text": "unaddressed channel chatter",
+            "channel": "C_CHAN",
+            "channel_type": "channel",
+            "ts": "171.444",
+            "user": "U_USER",
+            "team_id": "T_TEAM",
+        }
+    )
+
+    msg_event = adapter.handle_message.await_args.args[0]
+    assert msg_event.metadata["addressed_bot"] is False

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -302,6 +302,171 @@ class TestSlackWorkspaceCollisionIsolation:
 class TestAppMentionHandler:
     """Verify that the app_mention event handler is registered."""
 
+    def test_direct_token_connect_supplies_workspace_authorizer_with_oauth_env(self):
+        """Ambient OAuth setup must not replace Hermes's bot-token authority.
+
+        Slack Bolt auto-enables its installation-store authorization whenever
+        ``SLACK_CLIENT_ID`` and ``SLACK_CLIENT_SECRET`` exist. Hermes supplies
+        an explicit workspace-aware authorizer so valid Socket Mode events use
+        the already resolved bot token instead.
+        """
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+        async_app_kwargs = {}
+
+        mock_app = MagicMock()
+        mock_app.event.side_effect = lambda _event: lambda fn: fn
+        mock_app.command.side_effect = lambda _command: lambda fn: fn
+        mock_app.client = AsyncMock()
+
+        def build_app(*args, **kwargs):
+            async_app_kwargs.update(kwargs)
+            return mock_app
+
+        mock_web_client = AsyncMock()
+        mock_web_client.token = "xoxb-fake"
+        mock_web_client.auth_test = AsyncMock(
+            return_value={
+                "user_id": "U_BOT",
+                "bot_id": "B_BOT",
+                "user": "testbot",
+                "team_id": "T_FAKE",
+                "team": "FakeTeam",
+            }
+        )
+        socket_mode_handler = MagicMock()
+        socket_mode_handler.start_async = AsyncMock(return_value=None)
+
+        with (
+            patch.object(_slack_mod, "AsyncApp", side_effect=build_app),
+            patch.object(_slack_mod, "AsyncWebClient", return_value=mock_web_client),
+            patch.object(
+                _slack_mod, "AsyncSocketModeHandler", return_value=socket_mode_handler
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "SLACK_APP_TOKEN": "xapp-fake",
+                    "SLACK_CLIENT_ID": "ambient-client-id",
+                    "SLACK_CLIENT_SECRET": "ambient-client-secret",
+                },
+            ),
+            patch("gateway.status.acquire_scoped_lock", return_value=(True, None)),
+            patch("asyncio.create_task", side_effect=_fake_create_task),
+        ):
+            asyncio.run(adapter.connect())
+
+        assert async_app_kwargs["token"] == "xoxb-fake"
+        assert async_app_kwargs["client"] is mock_web_client
+        authorize = async_app_kwargs["authorize"]
+        result = asyncio.run(authorize(enterprise_id=None, team_id="T_FAKE"))
+        assert result.team_id == "T_FAKE"
+        assert result.bot_user_id == "U_BOT"
+        assert result.bot_token == "xoxb-fake"
+
+    @pytest.mark.parametrize(
+        ("clients", "bot_ids", "team_id", "expected"),
+        [
+            (
+                {"T_ONE": "xoxb-one"},
+                {"T_ONE": "U_ONE"},
+                "T_ONE",
+                ("T_ONE", "U_ONE", "xoxb-one"),
+            ),
+            (
+                {"T_ONE": "xoxb-one"},
+                {"T_ONE": "U_ONE"},
+                None,
+                ("T_ONE", "U_ONE", "xoxb-one"),
+            ),
+            ({"T_ONE": "xoxb-one"}, {"T_ONE": "U_ONE"}, "T_UNKNOWN", None),
+            (
+                {"T_ONE": "xoxb-one", "T_TWO": "xoxb-two"},
+                {"T_ONE": "U_ONE", "T_TWO": "U_TWO"},
+                "T_TWO",
+                ("T_TWO", "U_TWO", "xoxb-two"),
+            ),
+            (
+                {"T_ONE": "xoxb-one", "T_TWO": "xoxb-two"},
+                {"T_ONE": "U_ONE", "T_TWO": "U_TWO"},
+                "T_UNKNOWN",
+                None,
+            ),
+            (
+                {"T_ONE": "xoxb-one", "T_TWO": "xoxb-two"},
+                {"T_ONE": "U_ONE", "T_TWO": "U_TWO"},
+                None,
+                None,
+            ),
+        ],
+    )
+    def test_workspace_authorizer_routing_matrix(
+        self, clients, bot_ids, team_id, expected
+    ):
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        adapter._team_clients = {
+            key: MagicMock(token=token) for key, token in clients.items()
+        }
+        adapter._team_bot_user_ids = bot_ids
+
+        result = asyncio.run(
+            adapter._authorize_slack_request(enterprise_id=None, team_id=team_id)
+        )
+
+        if expected is None:
+            assert result is None
+        else:
+            expected_team, expected_bot, expected_token = expected
+            assert result.team_id == expected_team
+            assert result.bot_user_id == expected_bot
+            assert result.bot_token == expected_token
+
+    def test_real_bolt_uses_explicit_authorizer_with_ambient_oauth_env(self):
+        """Exercise Bolt's real authorization middleware selection and callback."""
+        import logging
+
+        from slack_bolt.async_app import AsyncApp as RealAsyncApp
+        from slack_bolt.context.async_context import AsyncBoltContext
+        from slack_sdk.web.async_client import AsyncWebClient
+
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        client = AsyncWebClient(token="xoxb-fake")
+        adapter._team_clients = {"T_FAKE": client}
+        adapter._team_bot_user_ids = {"T_FAKE": "U_BOT"}
+
+        async def authorize(enterprise_id=None, team_id=None):
+            return await adapter._authorize_slack_request(
+                enterprise_id=enterprise_id,
+                team_id=team_id,
+            )
+
+        with patch.dict(
+            os.environ,
+            {
+                "SLACK_BOT_TOKEN": "xoxb-fake",
+                "SLACK_CLIENT_ID": "ambient-client-id",
+                "SLACK_CLIENT_SECRET": "ambient-client-secret",
+            },
+        ):
+            app = RealAsyncApp(token="xoxb-fake", client=client, authorize=authorize)
+
+        context = AsyncBoltContext(
+            {"logger": logging.getLogger("slack-auth-test"), "client": client}
+        )
+        result = asyncio.run(
+            app._async_authorize(
+                context=context,
+                enterprise_id=None,
+                team_id="T_FAKE",
+                user_id="U_USER",
+            )
+        )
+
+        assert type(app._async_authorize).__name__ == "AsyncCallableAuthorize"
+        assert result.team_id == "T_FAKE"
+        assert result.bot_user_id == "U_BOT"
+        assert result.bot_token == "xoxb-fake"
+
     def test_app_mention_registered_on_connect(self):
         """connect() should register message + assistant lifecycle handlers."""
         config = PlatformConfig(enabled=True, token="xoxb-fake")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3092,6 +3092,67 @@ class TestAssistantThreadLifecycle:
 
 
     @pytest.mark.asyncio
+    async def test_assistant_thread_started_greets_once_and_sets_dynamic_prompts(
+        self, assistant_adapter
+    ):
+        assistant_adapter.config.extra["assistant_thread_greeting"] = (
+            "Hi, I’m Itô Desk. What are you working on?"
+        )
+        assistant_adapter.config.extra["suggested_prompts"] = {
+            "title": "Live desk",
+            "prompts": [
+                {"title": "Priorities", "message": "Show my current desk priorities"}
+            ],
+        }
+        assistant_adapter._app.client.chat_postMessage = AsyncMock()
+        assistant_adapter._app.client.assistant_threads_setSuggestedPrompts = AsyncMock()
+        event = {
+            "type": "assistant_thread_started",
+            "team_id": "T_TEAM",
+            "assistant_thread": {
+                "channel_id": "D123",
+                "thread_ts": "171.000",
+                "user_id": "U_USER",
+            },
+        }
+
+        await assistant_adapter._handle_assistant_thread_lifecycle_event(event)
+        await assistant_adapter._handle_assistant_thread_lifecycle_event(event)
+
+        assistant_adapter._app.client.chat_postMessage.assert_awaited_once_with(
+            channel="D123",
+            thread_ts="171.000",
+            text="Hi, I’m Itô Desk. What are you working on?",
+        )
+        assert (
+            assistant_adapter._app.client.assistant_threads_setSuggestedPrompts.await_count
+            == 2
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_assistant_thread_context_changed_never_greets(
+        self, assistant_adapter
+    ):
+        assistant_adapter.config.extra["assistant_thread_greeting"] = "Hi"
+        assistant_adapter._app.client.chat_postMessage = AsyncMock()
+
+        await assistant_adapter._handle_assistant_thread_lifecycle_event(
+            {
+                "type": "assistant_thread_context_changed",
+                "team_id": "T_TEAM",
+                "assistant_thread": {
+                    "channel_id": "D123",
+                    "thread_ts": "171.000",
+                    "user_id": "U_USER",
+                },
+            }
+        )
+
+        assistant_adapter._app.client.chat_postMessage.assert_not_awaited()
+
+
+    @pytest.mark.asyncio
     async def test_assistant_thread_cache_is_scoped_per_workspace(
         self, assistant_adapter
     ):


### PR DESCRIPTION
## What

Lane B of the 2026-08-25 night-shift orchestration: make the ito_desk Slack bot's outbound replies actually visible, guarantee a visible ack on direct addresses, and keep the approval flow working end to end.

Three commits on current upstream main (41447a6d70):

1. **dce916901e fix(slack): isolate direct-token auth from OAuth env** — (earlier session tonight) keep SLACK_BOT_TOKEN direct auth independent of OAuth env state.
2. **1640739b90 feat(slack): greet new assistant threads** — (earlier session tonight) greeting + suggested prompts for new assistant threads.
3. **75224de487 feat(gateway): never-silent ack for directly-addressed turns** — new gateway behavior: when a turn the user directly addressed (DM, @mention, reply in a bot thread) would end in total silence (agent emitted NO_REPLY/[SILENT]), the gateway replaces the silence with a minimal visible ack ("✓ Received."). Passive free-response ingestion keeps the intentional-silence path. Opt-out: `gateway.never_silent_ack: false`. Slack adapter marks `metadata["addressed_bot"]` on inbound events; unmarked platforms fall back conservatively (DM = direct, group = passive).

## Why

Production diagnosis on the ito gateway tonight: agent turns completed and the stream consumer correctly reported delivery — but every reply landed as a collapsed Slack thread reply under the inbound message, so the channel looked silent (`reply_in_thread` defaults true). Replies were verified present in thread history via the Slack API. Deploy-side fix is `platforms.slack.extra.reply_in_thread: false` in the ito profile (existing code path, no code change needed).

The never-silent ack closes the residual silence class as gateway behavior: a direct address can never again end with zero visible output, regardless of what the model chose to emit.

## Tests

- New: `tests/gateway/test_never_silent_ack.py` — 26 tests (ack decision, config opt-out, internal-event guard, Slack inbound marking for mention/DM/bot-thread-reply/free-response-passive).
- Adjacent suites: test_slack.py (175), test_slack_approval_buttons (20), test_delivery_silence_filter (19), test_duplicate_reply_suppression (9), test_gateway_silence_tokens (7), test_slack_thread_require_mention (5), test_slack_channel_session_scope (4), test_stream_consumer_silence (3) — 242 passed, 0 failed.

## Rollback

Revert the squash/merge commit. Deploy side: set `reply_in_thread: true` (or remove the key) in the ito profile config and restart the launchd gateway; the ack is inert when `gateway.never_silent_ack: false`.

## Production note

The ito production gateway runs a hand-assembled checkout at ~/.hermes/hermes-agent (not git-tracked, months behind upstream). This PR is the forward lineage; the production deploy applies the same never-silent ack semantics as a minimal patch onto that checkout plus the config flip, verified live in-channel.
