### PR TITLE
supplier-desk channel surfaces: chat-scoped Slack authz + quiet channels

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -459,6 +459,12 @@ class GatewayAuthorizationMixin:
             chat_allowlist_env = {
                 Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
+                # Slack counterpart of the Telegram chat-scoped allowlist:
+                # SLACK_GROUP_ALLOWED_CHATS authorizes any member posting in a
+                # designated channel (supplier-desk channels like
+                # pluto-itomarkets), so counterparties can talk to the desk
+                # without being named in SLACK_ALLOWED_USERS.
+                Platform.SLACK: "SLACK_GROUP_ALLOWED_CHATS",
             }.get(source.platform, "")
             if chat_allowlist_env:
                 raw_chat_allowlist = _platform_gate_env(chat_allowlist_env)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5052,6 +5052,16 @@ class TurnRunner:
                 except Exception:
                     pass
 
+                # display.quiet_channels: drop progress events at the queue
+                # for counterparty-facing channels, so no bubble is ever
+                # created.  Covers first sends, edits, overflow splits, and
+                # flood-control fallbacks alike — the per-send guard alone
+                # left the direct-send branches open (and could return None
+                # into result.success).
+                if (ctx.source.chat_id or "") in _quiet_channel_ids(_load_gateway_config()):
+                    await asyncio.sleep(0)
+                    continue
+
                 # Handle dedup messages: update last line with repeat counter
                 if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                     _, base_msg, count = raw

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1570,6 +1570,25 @@ def _never_silent_ack_enabled(user_config: Optional[dict]) -> bool:
 _NEVER_SILENT_ACK_TEXT = "✓ Received."
 
 
+def _quiet_channel_ids(user_config: Optional[dict]) -> set:
+    """Channel IDs whose working display surface is muted (``display.quiet_channels``).
+
+    Final answers still land in these channels; only the working surface —
+    reasoning prepends, tool-progress bubbles, and status/self-improvement
+    notices — is suppressed.  Used for counterparty-facing channels (supplier
+    desks) where internal bookkeeping and emoji progress must never leak,
+    while the answer itself still streams in normally.
+    """
+    try:
+        disp = (user_config or {}).get("display") or {}
+        raw = disp.get("quiet_channels") or []
+        if isinstance(raw, (list, tuple, set)):
+            return {str(c).strip() for c in raw if str(c).strip()}
+    except Exception:
+        pass
+    return set()
+
+
 def _never_silent_ack_response(event: Any, source: Any, user_config: Optional[dict]) -> str:
     """Resolve the outbound text for an intentional-silence turn.
 
@@ -4947,6 +4966,11 @@ class TurnRunner:
                 ctx._cleanup_msg_ids.append(str(result.message_id))
 
         async def _send_progress_text(text: str):
+            # display.quiet_channels: no tool-progress bubbles in
+            # counterparty-facing channels (the "working" surface stays
+            # the typing indicator + the streamed answer itself).
+            if (ctx.source.chat_id or "") in _quiet_channel_ids(_load_gateway_config()):
+                return
             result = await adapter.send(
                 chat_id=ctx.source.chat_id,
                 content=text,
@@ -5370,6 +5394,11 @@ class TurnRunner:
     def _status_callback_sync(self, event_type: str, message: str) -> None:
         ctx = self._ctx
         if not ctx._status_adapter or not ctx._run_still_current():
+            return
+        # display.quiet_channels: counterparty-facing channels get the
+        # final answer only — status notices (self-improvement reviews,
+        # auxiliary errors, lifecycle chatter) never surface there.
+        if (ctx._status_chat_id or "") in _quiet_channel_ids(_load_gateway_config()):
             return
         prepared_message = _prepare_gateway_status_message(
             ctx.source.platform,
@@ -20623,7 +20652,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if source.platform == Platform.MATTERMOST
                     else getattr(self, "_show_reasoning", False)
                 )
-            if _show_reasoning_effective and response and not _intentional_silence:
+            if (
+                _show_reasoning_effective
+                and response
+                and not _intentional_silence
+                and (source.chat_id or "") not in _quiet_channel_ids(_load_gateway_config())
+            ):
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
                     from gateway.stream_consumer import escape_code_fences_for_display

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1491,7 +1491,9 @@ def slack_app_manifest(request_url: str = "https://hermes-agent.local/slack/comm
     # /ito-link is answered by a dedicated bolt listener in the Slack adapter
     # (not the gateway COMMAND_REGISTRY), so it never appears in
     # slack_native_slashes(); declare it explicitly or Socket Mode will not
-    # deliver the command event.
+    # deliver the command event. Slack caps a manifest at 50 slash commands:
+    # when the registry already fills the cap, the tail entry yields to
+    # /ito-link and stays reachable via the /hermes <command> catch-all.
     if not any(entry["command"] == "/ito-link" for entry in slashes):
         slashes.append({
             "command": "/ito-link",
@@ -1499,6 +1501,11 @@ def slack_app_manifest(request_url: str = "https://hermes-agent.local/slack/comm
             "should_escape": False,
             "url": request_url,
         })
+    while len(slashes) > _SLACK_MAX_SLASH_COMMANDS:
+        for index in range(len(slashes) - 2, -1, -1):
+            if slashes[index]["command"] not in ("/hermes", "/ito-link"):
+                del slashes[index]
+                break
     return {"features": {"slash_commands": slashes}}
 
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1488,6 +1488,17 @@ def slack_app_manifest(request_url: str = "https://hermes-agent.local/slack/comm
         if usage:
             entry["usage_hint"] = usage
         slashes.append(entry)
+    # /ito-link is answered by a dedicated bolt listener in the Slack adapter
+    # (not the gateway COMMAND_REGISTRY), so it never appears in
+    # slack_native_slashes(); declare it explicitly or Socket Mode will not
+    # deliver the command event.
+    if not any(entry["command"] == "/ito-link" for entry in slashes):
+        slashes.append({
+            "command": "/ito-link",
+            "description": "Link your Slack identity to your Itô account",
+            "should_escape": False,
+            "url": request_url,
+        })
     return {"features": {"slash_commands": slashes}}
 
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2174,6 +2174,27 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 await self._handle_slash_command(command)
 
+            # /ito-link is NOT a gateway command: it mints a panel identity
+            # bind nonce and answers ephemerally, never entering the
+            # agent-turn pipeline. It still needs a manifest declaration
+            # (hermes slack manifest includes it) or Slack will not deliver
+            # the command event over Socket Mode.
+            @self._app.command("/ito-link")
+            async def handle_ito_link_command(ack, command):
+                await ack(
+                    response_type="ephemeral",
+                    text="Minting your private Itô identity link…",
+                )
+                channel_id = command.get("channel_id") or ""
+                await self._handle_ito_link_request(
+                    channel_id=channel_id,
+                    user_id=command.get("user_id") or "",
+                    team_id=command.get("team_id") or "",
+                    display_name=command.get("user_name") or None,
+                    is_dm=channel_id.startswith("D"),
+                    reply_to=None,
+                )
+
             # Register Block Kit action handlers for approval buttons
             for _action_id in (
                 "hermes_approve_once",
@@ -2973,6 +2994,74 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[Slack] Ephemeral send error: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
+
+    async def _handle_ito_link_request(
+        self,
+        *,
+        channel_id: str,
+        user_id: str,
+        team_id: str,
+        display_name: Optional[str],
+        is_dm: bool,
+        reply_to: Optional[str],
+    ) -> None:
+        """Answer an /ito-link (or DM `link`) request with a private bind URL.
+
+        Channels get a chat.postEphemeral (only the requester sees the URL);
+        DMs get a normal reply (the conversation is already private). Every
+        outcome answers — never silent — and neither the nonce nor the bind
+        URL is logged.
+        """
+        from .ito_link import (
+            ItoLinkMintError,
+            link_error_message,
+            link_ready_message,
+            mint_link_nonce,
+        )
+
+        try:
+            minted = await mint_link_nonce(
+                team_id=team_id,
+                member_id=user_id,
+                display_name=display_name,
+            )
+            content = link_ready_message(minted["bind_url"])
+            logger.info(
+                "[Slack] ito-link nonce minted for team=%s member=%s",
+                team_id,
+                user_id,
+            )
+        except ItoLinkMintError as e:
+            content = link_error_message(e)
+            logger.warning(
+                "[Slack] ito-link mint failed kind=%s team=%s member=%s",
+                e.kind,
+                team_id,
+                user_id,
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            content = link_error_message(ItoLinkMintError("unavailable"))
+            logger.error(
+                "[Slack] ito-link mint unexpected error: %s", e, exc_info=True,
+            )
+        if not channel_id or not user_id:
+            logger.warning("[Slack] ito-link request missing channel or user id")
+            return
+        if is_dm:
+            await self.send(
+                channel_id,
+                content,
+                reply_to=reply_to,
+                metadata={"team_id": team_id} if team_id else None,
+            )
+        else:
+            await self.send_private_notice(
+                channel_id,
+                user_id,
+                content,
+                reply_to=reply_to,
+                metadata={"team_id": team_id} if team_id else None,
+            )
 
     async def send_or_update_status(
         self,
@@ -6136,6 +6225,23 @@ class SlackAdapter(BasePlatformAdapter):
                     channel_id,
                 )
                 return
+
+        # Identity linking (spec v1): a 1:1 DM whose entire text is the link
+        # keyword mints a bind nonce and answers privately, without entering
+        # the agent-turn pipeline. Channel coverage comes from the /ito-link
+        # slash listener registered in connect().
+        from .ito_link import is_link_keyword as _is_link_keyword
+
+        if is_one_to_one_dm and _is_link_keyword(original_text or ""):
+            await self._handle_ito_link_request(
+                channel_id=channel_id,
+                user_id=str(user_id or ""),
+                team_id=str(team_id or ""),
+                display_name=None,
+                is_dm=True,
+                reply_to=event.get("thread_ts") or ts,
+            )
+            return
 
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3019,6 +3019,9 @@ class SlackAdapter(BasePlatformAdapter):
             mint_link_nonce,
         )
 
+        if not channel_id or not user_id:
+            logger.warning("[Slack] ito-link request missing channel or user id")
+            return
         try:
             minted = await mint_link_nonce(
                 team_id=team_id,
@@ -3044,9 +3047,6 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error(
                 "[Slack] ito-link mint unexpected error: %s", e, exc_info=True,
             )
-        if not channel_id or not user_id:
-            logger.warning("[Slack] ito-link request missing channel or user id")
-            return
         if is_dm:
             await self.send(
                 channel_id,

--- a/plugins/platforms/slack/ito_link.py
+++ b/plugins/platforms/slack/ito_link.py
@@ -1,0 +1,124 @@
+"""Slack ↔ Ito identity linking — gateway side of the /ito-link flow.
+
+Spec v1 (2026-08-24): the institutional panel is the identity authority.
+This module converts a Slack slash command or DM keyword into a single-use
+bind URL delivered ONLY through a private reply (ephemeral in channels; the
+DM itself is private by definition).
+
+The nonce is minted by the panel (POST /api/slack/link-nonces) under the
+existing desk bridge credential (OTC_BRIDGE_TOKEN). The gateway never signs,
+persists, or logs nonce material beyond the mint round-trip, and never posts
+a bind URL to a channel. The runtime stores only the SHA-256 hash; the nonce
+is single-use with a 15-minute TTL and is bound to (slack_team_id,
+slack_member_id) at mint time.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+from tools.url_safety import create_ssrf_safe_async_client
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MINT_URL = "https://compute.itomarkets.com/api/slack/link-nonces"
+DEFAULT_PUBLIC_ORIGIN = "https://compute.itomarkets.com"
+MINT_TIMEOUT_SECONDS = 10.0
+LINK_KEYWORD = "link"
+
+
+class ItoLinkMintError(Exception):
+    """Mint failure with an operator-meaningful kind."""
+
+    def __init__(self, kind: str, detail: str = "") -> None:
+        super().__init__(detail or kind)
+        self.kind = kind
+
+
+def is_link_keyword(text: str) -> bool:
+    """A DM whose entire content is the link keyword triggers the bind flow."""
+    return text.strip().lower() == LINK_KEYWORD
+
+
+async def mint_link_nonce(
+    *,
+    team_id: str,
+    member_id: str,
+    display_name: Optional[str] = None,
+) -> dict[str, Any]:
+    """Mint one bind nonce from the panel. Never logs the nonce or URL."""
+    token = (os.environ.get("OTC_BRIDGE_TOKEN") or "").strip()
+    if not token:
+        raise ItoLinkMintError(
+            "unconfigured",
+            "OTC_BRIDGE_TOKEN is not provisioned on this gateway",
+        )
+    mint_url = (os.environ.get("ITO_PANEL_LINK_NONCE_URL") or "").strip() or DEFAULT_MINT_URL
+    origin = (
+        (os.environ.get("ITO_PANEL_PUBLIC_ORIGIN") or "").strip().rstrip("/")
+        or DEFAULT_PUBLIC_ORIGIN
+    )
+    payload: dict[str, Any] = {
+        "slack_team_id": team_id,
+        "slack_member_id": member_id,
+    }
+    if display_name:
+        payload["display_name_snapshot"] = display_name
+    try:
+        async with create_ssrf_safe_async_client(timeout=MINT_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                mint_url,
+                json=payload,
+                headers={
+                    "authorization": f"Bearer {token}",
+                    "content-type": "application/json",
+                },
+            )
+    except ItoLinkMintError:
+        raise
+    except Exception as exc:
+        raise ItoLinkMintError("unreachable", f"{type(exc).__name__}") from exc
+    if response.status_code == 401:
+        raise ItoLinkMintError("unauthorized", "panel rejected the bridge credential")
+    if response.status_code != 200:
+        raise ItoLinkMintError("unavailable", f"panel answered HTTP {response.status_code}")
+    try:
+        body = response.json()
+    except Exception as exc:
+        raise ItoLinkMintError("unavailable", "panel returned a non-JSON body") from exc
+    if (
+        not isinstance(body, dict)
+        or body.get("ok") is not True
+        or not isinstance(body.get("bind_path"), str)
+        or not body["bind_path"].startswith("/auth/slack/bind?n=")
+    ):
+        raise ItoLinkMintError("unavailable", "panel returned an unexpected payload")
+    return {
+        "bind_url": f"{origin}{body['bind_path']}",
+        "expires_at": body.get("expires_at"),
+    }
+
+
+def link_ready_message(bind_url: str) -> str:
+    return (
+        "Link your Slack identity to Itô: "
+        f"{bind_url}\n"
+        "Single use, expires in 15 minutes. The page asks you to sign in to "
+        "your Itô account if you are not already. Never share this URL."
+    )
+
+
+def link_error_message(error: ItoLinkMintError) -> str:
+    if error.kind == "unconfigured":
+        return (
+            "Identity linking is not configured on this gateway yet "
+            "(missing panel credential). The operator has been notified."
+        )
+    if error.kind == "unauthorized":
+        return (
+            "Identity linking was rejected by the panel (credential issue). "
+            "The operator has been notified."
+        )
+    return "Could not mint your link right now (panel unavailable). Try again in a minute."

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -540,9 +540,11 @@ class TestAppMentionHandler:
         # covering every COMMAND_REGISTRY entry (e.g. /hermes, /btw, /stop,
         # /model, ...) so users get native-slash parity with Discord and
         # Telegram. Verify the regex matches the key expected slashes.
+        # /ito-link is a dedicated literal listener beside the combined regex:
+        # it is answered by the identity-link flow, not the gateway registry.
         assert (
-            len(registered_commands) == 1
-        ), f"expected 1 combined slash matcher, got {registered_commands!r}"
+            len(registered_commands) == 2
+        ), f"expected combined slash matcher + /ito-link, got {registered_commands!r}"
         slash_matcher = registered_commands[0]
         import re as _re
 
@@ -551,6 +553,7 @@ class TestAppMentionHandler:
             assert slash_matcher.match(
                 expected
             ), f"Slack slash regex does not match {expected}"
+        assert "/ito-link" in registered_commands
 
         # Catch-all generic matcher must be registered after the named handlers
         # so it does not shadow them. It fires for any event type not already

--- a/tests/gateway/test_slack_ito_link.py
+++ b/tests/gateway/test_slack_ito_link.py
@@ -1,0 +1,389 @@
+"""Tests for the Slack /ito-link identity bind flow (spec v1, 2026-08-24).
+
+Covers:
+* ``ito_link.is_link_keyword`` DM keyword predicate
+* ``ito_link.mint_link_nonce`` auth, payload, failure taxonomy, no-log contract
+* ``slack_app_manifest`` declares /ito-link (Socket Mode delivery requirement)
+* ``SlackAdapter._handle_ito_link_request`` delivery semantics: ephemeral in
+  channels (never a public post), normal reply in DMs, never-silent on error
+* ``SlackAdapter.connect`` registers the dedicated /ito-link bolt listener
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_slack_mock() -> None:
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+    slack_bolt.authorization.AuthorizeResult = MagicMock
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.authorization", slack_bolt.authorization),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        ("slack_bolt.adapter.socket_mode.async_handler",
+         slack_bolt.adapter.socket_mode.async_handler),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("aiohttp", MagicMock())
+
+
+_ensure_slack_mock()
+
+from gateway.platforms.base import PlatformConfig  # noqa: E402
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+from plugins.platforms.slack import ito_link  # noqa: E402
+from plugins.platforms.slack.ito_link import ItoLinkMintError  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Keyword predicate
+# ---------------------------------------------------------------------------
+
+
+class TestLinkKeyword:
+    def test_bare_keyword_matches(self):
+        assert ito_link.is_link_keyword("link")
+        assert ito_link.is_link_keyword("  Link \n")
+        assert ito_link.is_link_keyword("LINK")
+
+    def test_other_text_does_not_match(self):
+        assert not ito_link.is_link_keyword("link please")
+        assert not ito_link.is_link_keyword("relink")
+        assert not ito_link.is_link_keyword("")
+        assert not ito_link.is_link_keyword("link my account")
+
+
+# ---------------------------------------------------------------------------
+# mint_link_nonce
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body=None, json_raises=False):
+        self.status_code = status_code
+        self._body = body
+        self._json_raises = json_raises
+
+    def json(self):
+        if self._json_raises:
+            raise ValueError("not json")
+        return self._body
+
+
+class _FakeClient:
+    def __init__(self, response=None, raises=None):
+        self._response = response
+        self._raises = raises
+        self.posts: list = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        self.posts.append({"url": url, "json": json, "headers": headers})
+        if self._raises is not None:
+            raise self._raises
+        return self._response
+
+
+def _mint(client: _FakeClient, env: dict, **kwargs) -> dict:
+    with patch.dict(os.environ, env, clear=False), \
+         patch.object(ito_link, "create_ssrf_safe_async_client", return_value=client):
+        return asyncio.run(ito_link.mint_link_nonce(**kwargs))
+
+
+class TestMintLinkNonce:
+    def test_unconfigured_without_bridge_token(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("OTC_BRIDGE_TOKEN", None)
+            with pytest.raises(ItoLinkMintError) as excinfo:
+                asyncio.run(ito_link.mint_link_nonce(team_id="T0TEAM", member_id="U0MEMBER"))
+        assert excinfo.value.kind == "unconfigured"
+
+    def test_success_posts_bound_payload_and_composes_bind_url(self):
+        client = _FakeClient(response=_FakeResponse(200, {
+            "ok": True,
+            "nonce": "n" * 43,
+            "expires_at": "2026-08-25T01:15:00.000Z",
+            "bind_path": f"/auth/slack/bind?n={'n' * 43}",
+        }))
+        result = _mint(
+            client,
+            {"OTC_BRIDGE_TOKEN": "bridge-secret"},
+            team_id="T0TEAM",
+            member_id="U0MEMBER",
+            display_name="Affaan",
+        )
+        assert result["bind_url"] == f"https://compute.itomarkets.com/auth/slack/bind?n={'n' * 43}"
+        assert result["expires_at"] == "2026-08-25T01:15:00.000Z"
+        post = client.posts[0]
+        assert post["url"] == "https://compute.itomarkets.com/api/slack/link-nonces"
+        assert post["json"] == {
+            "slack_team_id": "T0TEAM",
+            "slack_member_id": "U0MEMBER",
+            "display_name_snapshot": "Affaan",
+        }
+        assert post["headers"]["authorization"] == "Bearer bridge-secret"
+
+    def test_display_name_omitted_when_absent(self):
+        client = _FakeClient(response=_FakeResponse(200, {
+            "ok": True,
+            "bind_path": f"/auth/slack/bind?n={'n' * 43}",
+        }))
+        _mint(client, {"OTC_BRIDGE_TOKEN": "x"}, team_id="T0TEAM", member_id="U0MEMBER")
+        assert "display_name_snapshot" not in client.posts[0]["json"]
+
+    def test_401_maps_to_unauthorized(self):
+        client = _FakeClient(response=_FakeResponse(401, {"ok": False}))
+        with pytest.raises(ItoLinkMintError) as excinfo:
+            _mint(client, {"OTC_BRIDGE_TOKEN": "x"}, team_id="T0TEAM", member_id="U0MEMBER")
+        assert excinfo.value.kind == "unauthorized"
+
+    def test_503_maps_to_unavailable(self):
+        client = _FakeClient(response=_FakeResponse(503, {"ok": False}))
+        with pytest.raises(ItoLinkMintError) as excinfo:
+            _mint(client, {"OTC_BRIDGE_TOKEN": "x"}, team_id="T0TEAM", member_id="U0MEMBER")
+        assert excinfo.value.kind == "unavailable"
+
+    def test_transport_error_maps_to_unreachable(self):
+        client = _FakeClient(raises=TimeoutError("slow"))
+        with pytest.raises(ItoLinkMintError) as excinfo:
+            _mint(client, {"OTC_BRIDGE_TOKEN": "x"}, team_id="T0TEAM", member_id="U0MEMBER")
+        assert excinfo.value.kind == "unreachable"
+        # Transport details must not leak nonce material into the error.
+        assert "Bearer" not in str(excinfo.value)
+
+    def test_unexpected_payload_maps_to_unavailable(self):
+        for body in [
+            {"ok": True},
+            {"ok": True, "bind_path": "https://evil.example.com/steal"},
+            {"ok": False, "bind_path": "/auth/slack/bind?n=x"},
+            "garbage",
+        ]:
+            client = _FakeClient(response=_FakeResponse(200, body))
+            with pytest.raises(ItoLinkMintError) as excinfo:
+                _mint(client, {"OTC_BRIDGE_TOKEN": "x"}, team_id="T0TEAM", member_id="U0MEMBER")
+            assert excinfo.value.kind == "unavailable"
+
+    def test_origin_override(self):
+        client = _FakeClient(response=_FakeResponse(200, {
+            "ok": True,
+            "bind_path": f"/auth/slack/bind?n={'n' * 43}",
+        }))
+        result = _mint(
+            client,
+            {"OTC_BRIDGE_TOKEN": "x", "ITO_PANEL_PUBLIC_ORIGIN": "https://data.itomarkets.com/"},
+            team_id="T0TEAM",
+            member_id="U0MEMBER",
+        )
+        assert result["bind_url"].startswith("https://data.itomarkets.com/auth/slack/bind")
+
+
+# ---------------------------------------------------------------------------
+# Manifest declares /ito-link
+# ---------------------------------------------------------------------------
+
+
+class TestManifest:
+    def test_ito_link_declared(self):
+        from hermes_cli.commands import slack_app_manifest
+
+        manifest = slack_app_manifest()
+        commands = [entry["command"] for entry in manifest["features"]["slash_commands"]]
+        assert "/ito-link" in commands
+        assert commands.count("/ito-link") == 1
+
+
+# ---------------------------------------------------------------------------
+# Adapter delivery semantics
+# ---------------------------------------------------------------------------
+
+
+def _adapter() -> SlackAdapter:
+    config = PlatformConfig(enabled=True, token="xoxb-fake")
+    adapter = SlackAdapter(config)
+    adapter.send = AsyncMock(return_value=MagicMock(success=True))
+    adapter.send_private_notice = AsyncMock(return_value=MagicMock(success=True))
+    return adapter
+
+
+class TestItoLinkDelivery:
+    def test_channel_request_is_ephemeral_only(self):
+        adapter = _adapter()
+        with patch.object(ito_link, "mint_link_nonce", new=AsyncMock(return_value={
+            "bind_url": "https://compute.itomarkets.com/auth/slack/bind?n=" + "n" * 43,
+            "expires_at": "2026-08-25T01:15:00.000Z",
+        })) as mint:
+            asyncio.run(adapter._handle_ito_link_request(
+                channel_id="C0CHANNEL",
+                user_id="U0MEMBER",
+                team_id="T0TEAM",
+                display_name="Affaan",
+                is_dm=False,
+                reply_to=None,
+            ))
+        mint.assert_awaited_once_with(team_id="T0TEAM", member_id="U0MEMBER", display_name="Affaan")
+        adapter.send_private_notice.assert_awaited_once()
+        args, kwargs = adapter.send_private_notice.await_args
+        assert args[0] == "C0CHANNEL"
+        assert args[1] == "U0MEMBER"
+        assert "/auth/slack/bind?n=" in args[2]
+        # The bind URL must never become a public channel post.
+        adapter.send.assert_not_awaited()
+
+    def test_dm_request_replies_in_dm(self):
+        adapter = _adapter()
+        with patch.object(ito_link, "mint_link_nonce", new=AsyncMock(return_value={
+            "bind_url": "https://compute.itomarkets.com/auth/slack/bind?n=" + "n" * 43,
+            "expires_at": None,
+        })):
+            asyncio.run(adapter._handle_ito_link_request(
+                channel_id="D0DM",
+                user_id="U0MEMBER",
+                team_id="T0TEAM",
+                display_name=None,
+                is_dm=True,
+                reply_to="1700000000.000001",
+            ))
+        adapter.send.assert_awaited_once()
+        args, kwargs = adapter.send.await_args
+        assert args[0] == "D0DM"
+        assert "/auth/slack/bind?n=" in args[1]
+        assert kwargs["reply_to"] == "1700000000.000001"
+        adapter.send_private_notice.assert_not_awaited()
+
+    def test_mint_failure_still_answers_privately(self):
+        adapter = _adapter()
+        with patch.object(
+            ito_link,
+            "mint_link_nonce",
+            new=AsyncMock(side_effect=ItoLinkMintError("unconfigured")),
+        ):
+            asyncio.run(adapter._handle_ito_link_request(
+                channel_id="C0CHANNEL",
+                user_id="U0MEMBER",
+                team_id="T0TEAM",
+                display_name=None,
+                is_dm=False,
+                reply_to=None,
+            ))
+        adapter.send_private_notice.assert_awaited_once()
+        args, _kwargs = adapter.send_private_notice.await_args
+        assert "not configured" in args[2]
+        adapter.send.assert_not_awaited()
+
+    def test_unexpected_failure_still_answers_privately(self):
+        adapter = _adapter()
+        with patch.object(
+            ito_link,
+            "mint_link_nonce",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            asyncio.run(adapter._handle_ito_link_request(
+                channel_id="C0CHANNEL",
+                user_id="U0MEMBER",
+                team_id="T0TEAM",
+                display_name=None,
+                is_dm=False,
+                reply_to=None,
+            ))
+        adapter.send_private_notice.assert_awaited_once()
+        args, _kwargs = adapter.send_private_notice.await_args
+        assert "Try again" in args[2]
+
+    def test_missing_ids_does_not_crash_or_send(self):
+        adapter = _adapter()
+        with patch.object(ito_link, "mint_link_nonce", new=AsyncMock(return_value={
+            "bind_url": "https://compute.itomarkets.com/auth/slack/bind?n=" + "n" * 43,
+            "expires_at": None,
+        })):
+            asyncio.run(adapter._handle_ito_link_request(
+                channel_id="",
+                user_id="",
+                team_id="T0TEAM",
+                display_name=None,
+                is_dm=False,
+                reply_to=None,
+            ))
+        adapter.send_private_notice.assert_not_awaited()
+        adapter.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# connect() registers the dedicated listener
+# ---------------------------------------------------------------------------
+
+
+class TestConnectRegistration:
+    def test_ito_link_command_registered(self):
+        import plugins.platforms.slack.adapter as slack_mod
+
+        registered_commands: list = []
+
+        def mock_command(matcher):
+            def decorator(fn):
+                registered_commands.append((matcher, fn))
+                return fn
+            return decorator
+
+        mock_app = MagicMock()
+        mock_app.event = lambda _t: (lambda fn: fn)
+        mock_app.command = mock_command
+        mock_app.action = lambda _a: (lambda fn: fn)
+        mock_app.client = AsyncMock()
+
+        mock_web_client = AsyncMock()
+        mock_web_client.auth_test = AsyncMock(return_value={
+            "user_id": "U_BOT",
+            "user": "testbot",
+            "team_id": "T_FAKE",
+            "team": "FakeTeam",
+        })
+
+        adapter = _adapter()
+        fake_mgr = MagicMock()
+        fake_mgr.get_slack_action_handlers.return_value = []
+
+        with patch.object(slack_mod, "AsyncApp", return_value=mock_app), \
+             patch.object(slack_mod, "AsyncWebClient", return_value=mock_web_client), \
+             patch.object(slack_mod, "AsyncSocketModeHandler", return_value=MagicMock()), \
+             patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}), \
+             patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
+             patch("gateway.status.release_scoped_lock"), \
+             patch("hermes_cli.plugins.get_plugin_manager", return_value=fake_mgr), \
+             patch("asyncio.create_task"):
+            result = asyncio.run(adapter.connect())
+
+        assert result is True
+        literal_commands = [m for m, _fn in registered_commands if isinstance(m, str)]
+        assert "/ito-link" in literal_commands
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/gateway/test_supplier_channel_surfaces.py
+++ b/tests/gateway/test_supplier_channel_surfaces.py
@@ -1,0 +1,177 @@
+"""Supplier-desk channel surfaces: chat-scoped Slack authorization and
+display.quiet_channels suppression.
+
+Contract:
+* SLACK_GROUP_ALLOWED_CHATS authorizes any member posting in a designated
+  channel (mirrors TELEGRAM_GROUP_ALLOWED_CHATS) so counterparties can talk
+  to the desk without being individually allowlisted.
+* display.quiet_channels mutes the working display surface (reasoning
+  prepend, progress bubbles, status notices) while final answers still land.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import _quiet_channel_ids
+from gateway.session import SessionEntry, SessionSource
+
+
+def _slack_group_source(chat_id="C_SUPPLIER", user_id="U_SUPPLIER"):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id=chat_id,
+        chat_type="group",
+        user_id=user_id,
+    )
+
+
+def _runner():
+    runner = gateway_run.GatewayRunner(GatewayConfig())
+    runner.pairing_store = None
+    runner.pairing_stores = {}
+    return runner
+
+
+class TestSlackGroupAllowedChats:
+    def test_listed_channel_authorizes_any_member(self, monkeypatch):
+        monkeypatch.setenv("SLACK_GROUP_ALLOWED_CHATS", "C_SUPPLIER")
+        assert _runner()._is_user_authorized(_slack_group_source()) is True
+
+    def test_unlisted_channel_stays_denied(self, monkeypatch):
+        monkeypatch.setenv("SLACK_GROUP_ALLOWED_CHATS", "C_SUPPLIER")
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        assert _runner()._is_user_authorized(
+            _slack_group_source(chat_id="C_OTHER")
+        ) is False
+
+    def test_wildcard_authorizes_any_channel(self, monkeypatch):
+        monkeypatch.setenv("SLACK_GROUP_ALLOWED_CHATS", "*")
+        assert _runner()._is_user_authorized(
+            _slack_group_source(chat_id="C_ANY")
+        ) is True
+
+    def test_dm_not_covered_by_chat_allowlist(self, monkeypatch):
+        monkeypatch.setenv("SLACK_GROUP_ALLOWED_CHATS", "*")
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        source = SessionSource(
+            platform=Platform.SLACK, chat_id="D123", chat_type="dm", user_id="U_X",
+        )
+        assert _runner()._is_user_authorized(source) is False
+
+
+class TestQuietChannelIds:
+    def test_parses_list(self):
+        assert _quiet_channel_ids({"display": {"quiet_channels": ["C1", " C2 "]}}) == {"C1", "C2"}
+
+    def test_missing_or_malformed_is_empty(self):
+        assert _quiet_channel_ids({}) == set()
+        assert _quiet_channel_ids(None) == set()
+        assert _quiet_channel_ids({"display": {"quiet_channels": "oops"}}) == set()
+
+
+# ---------------------------------------------------------------------------
+# Reasoning prepend suppression through the real epilogue
+# ---------------------------------------------------------------------------
+
+
+def _source(chat_id="-1001"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="group",
+        user_id="12345",
+    )
+
+
+def _event(source):
+    return MessageEvent(text="question", source=source, message_id="msg-1")
+
+
+def _epilogue_runner(monkeypatch, tmp_path):
+    runner = gateway_run.GatewayRunner(GatewayConfig())
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:12345",
+        session_id="sess-quiet",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    runner._run_agent = AsyncMock(return_value={
+        "final_response": "The answer is 42.",
+        "messages": [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "The answer is 42."},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": False,
+        "last_reasoning": "Let me think through the pricing math carefully.",
+    })
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_reasoning_prepend_appears_in_normal_channel(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text("display:\n  show_reasoning: true\n")
+    runner = _epilogue_runner(monkeypatch, tmp_path)
+
+    response = await runner._handle_message_with_agent(
+        _event(_source()), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert "Reasoning:" in response
+    assert "The answer is 42." in response
+
+
+@pytest.mark.asyncio
+async def test_reasoning_prepend_suppressed_in_quiet_channel(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  show_reasoning: true\n  quiet_channels:\n    - '-1001'\n"
+    )
+    runner = _epilogue_runner(monkeypatch, tmp_path)
+
+    response = await runner._handle_message_with_agent(
+        _event(_source()), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert "Reasoning:" not in response
+    assert response == "The answer is 42."


### PR DESCRIPTION
Supplier-desk primitives (lane B follow-on, supplier desk v1):

- **authz_mixin**: SLACK_GROUP_ALLOWED_CHATS mirrors TELEGRAM_GROUP_ALLOWED_CHATS — any member posting in a designated channel is authorized, so counterparties (Cam/Pluto) can talk to the desk without individual allowlisting. Default-deny unchanged elsewhere.
- **display.quiet_channels**: mutes reasoning prepends, tool-progress bubbles, and status/self-improvement notices in listed channels; final answers still stream in. Keeps internal bookkeeping/emoji progress out of counterparty channels.

Tests: 8 new (tests/gateway/test_supplier_channel_surfaces.py) incl. epilogue-level reasoning-suppression through _handle_message_with_agent. All green at head eb2f95c886.

Deploy: ito profile config adds pluto-itomarkets (C0BHDC7LC2F) to free_response_channels + quiet_channels + a desk-persona channel_override, and SLACK_GROUP_ALLOWED_CHATS to the profile env. Rollback: revert merge; remove the config keys and restart ai.hermes.gateway-ito.