### PR TITLE
fix(gateway): no long-running heartbeat bubbles in quiet channels

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29234,7 +29234,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
 
-        _notify_task = asyncio.create_task(_notify_long_running())
+        # display.quiet_channels: no "⏳ Working — N min" heartbeat bubbles in
+        # counterparty-facing channels.  The desk works quietly there; the
+        # only working indicator is the assistant typing status.
+        if (source.chat_id or "") in _quiet_channel_ids(_load_gateway_config()):
+            _notify_task = None
+        else:
+            _notify_task = asyncio.create_task(_notify_long_running())
 
         def _stream_confirmed_final_delivery(
             consumer,


### PR DESCRIPTION
The '⏳ Working — N min — iteration X/200' heartbeat notification was the last ungated display path leaking working traces into counterparty-facing channels (a bubble landed in the pluto-itomarkets supplier channel on a live deal, 2026-08-26 12:16). Gate task creation on display.quiet_channels; the assistant typing status remains the only working indicator there. Verified live: bubble deleted, no new heartbeats after restart.