### PR TITLE
fix(gateway): guard _notify_task cancel for quiet-channel None

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29963,7 +29963,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if log_task:
                 log_task.cancel()
             interrupt_monitor.cancel()
-            _notify_task.cancel()
+            # _notify_task is None for quiet channels (heartbeat suppressed).
+            if _notify_task:
+                _notify_task.cancel()
 
             # Wait for stream consumer to finish its final edit
             if stream_task:


### PR DESCRIPTION
The quiet-channel heartbeat gate set _notify_task to None, but turn-end cleanup called .cancel() unconditionally — every quiet-channel turn crashed at completion with a visible 'unexpected error' message (two landed in the live pluto-itomarkets supplier channel). Guard the cancel. Verified live: a full DocuSign-preparation turn in the quiet channel now completes cleanly and files its approval (#223). Broken messages deleted from the channel.