### PR TITLE
channel splits + operator reroute + silent queue for supplier desks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1608,6 +1608,78 @@ def _never_silent_ack_response(event: Any, source: Any, user_config: Optional[di
     return ""
 
 
+def _is_operator_source(source: Any) -> bool:
+    """Whether the source user is an operator on the platform user allowlist
+    (e.g. SLACK_ALLOWED_USERS), as opposed to a counterparty admitted through
+    a chat-scoped allowlist (SLACK_GROUP_ALLOWED_CHATS)."""
+    plat = getattr(source, "platform", None)
+    env_name = {
+        "slack": "SLACK_ALLOWED_USERS",
+        "telegram": "TELEGRAM_ALLOWED_USERS",
+    }.get(str(getattr(plat, "value", plat) or "").lower(), "")
+    if not env_name:
+        return False
+    raw = os.getenv(env_name, "")
+    allowed = {p.strip().lower() for p in raw.replace(",", " ").split() if p.strip()}
+    if not allowed:
+        return False
+    uid = str(getattr(source, "user_id", "") or "").lower()
+    uname = str(getattr(source, "user_name", "") or "").lower()
+    return bool((uid and uid in allowed) or (uname and uname in allowed))
+
+
+def _operator_unaddressed_in_quiet(event: Any, source: Any, user_config: Optional[dict]) -> bool:
+    """True when an operator sent a message NOT addressed to the bot in a
+    display.quiet_channels channel (e.g. answering the counterparty directly
+    in a supplier-desk channel).
+
+    Those turns are operator bookkeeping (draft internals, status chatter):
+    the response is rerouted to the platform home channel and nothing is
+    streamed into the counterparty-facing channel.  Counterparty messages
+    and bot-addressed messages keep normal in-channel behavior.
+    """
+    if (getattr(source, "chat_id", "") or "") not in _quiet_channel_ids(user_config):
+        return False
+    if _event_addressed_bot(event, source):
+        return False
+    return _is_operator_source(source)
+
+
+def _jobs_notice_chat(user_config: Optional[dict], source: Any) -> str:
+    """Channel that receives background-job lifecycle notices.
+
+    For internal chats, when ``gateway.jobs_channel`` is set, completion and
+    failure notices go there instead of the origin chat (the #ito-jobs
+    split).  Counterparty-facing (quiet) channels keep in-channel delivery
+    so desk answers stay with the conversation.
+    """
+    origin = getattr(source, "chat_id", "") or ""
+    if origin in _quiet_channel_ids(user_config):
+        return origin
+    try:
+        gw = (user_config or {}).get("gateway") or {}
+        target = str(gw.get("jobs_channel") or "").strip()
+    except Exception:
+        target = ""
+    return target or origin
+
+
+def _trace_notice_chat(user_config: Optional[dict], source: Any) -> str:
+    """Channel that receives self-improvement / background-review traces.
+
+    These are internal bookkeeping: in counterparty-facing (quiet) channels
+    they are suppressed entirely (handled at the caller); for internal chats
+    they route to ``gateway.desk_log_channel`` when set (the #ito-desk-log
+    split) so the home channel stays a clean ops summary.
+    """
+    try:
+        gw = (user_config or {}).get("gateway") or {}
+        target = str(gw.get("desk_log_channel") or "").strip()
+    except Exception:
+        target = ""
+    return target or (getattr(source, "chat_id", "") or "")
+
+
 def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
     """True when gateway.message_timestamps.enabled is opted in.
 
@@ -5543,7 +5615,7 @@ class TurnRunner:
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
-        _want_stream_deltas = _streaming_enabled
+        _want_stream_deltas = _streaming_enabled and not ctx.suppress_streaming
         _want_interim_messages = ctx.interim_assistant_messages_enabled
         _want_interim_consumer = _want_interim_messages
         if _want_stream_deltas or _want_interim_consumer:
@@ -5989,9 +6061,17 @@ class TurnRunner:
         def _deliver_bg_review_message(message: str) -> None:
             if not ctx._status_adapter or not ctx._run_still_current():
                 return
+            # display.quiet_channels: self-improvement/memory notices are
+            # internal bookkeeping — never in counterparty channels.
+            # gateway.desk_log_channel: in internal channels they route to
+            # the desk-log channel instead of the origin chat.
+            _bg_cfg = _load_gateway_config()
+            if (ctx._status_chat_id or "") in _quiet_channel_ids(_bg_cfg):
+                return
+            _trace_chat_id = _trace_notice_chat(_bg_cfg, ctx.source)
             safe_schedule_threadsafe(
                 ctx._status_adapter.send(
-                    ctx._status_chat_id,
+                    _trace_chat_id,
                     message,
                     metadata=_interim_metadata(_non_conversational_metadata(ctx._status_thread_metadata, platform=ctx.source.platform)),
                 ),
@@ -10542,6 +10622,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # merge semantics for media.
         if not steered and not redirected:
             self._queue_or_replace_pending_event(session_key, event)
+
+        # display.quiet_channels: follow-ups in counterparty-facing channels
+        # queue silently.  The desk's live turn is never interrupted and no
+        # "Interrupting current task" ack is ever shown to a supplier; the
+        # queued message is answered in order when the current turn ends.
+        if (event.source.chat_id or "") in _quiet_channel_ids(_load_gateway_config()):
+            return True
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
@@ -20499,6 +20586,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=event.message_type,
+                suppress_streaming=_operator_unaddressed_in_quiet(
+                    event, source, _load_gateway_config(),
+                ),
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
 
@@ -21140,6 +21230,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception:
                     pass
                 return None
+
+            # Operator bookkeeping reroute: an operator's unaddressed message
+            # in a quiet (counterparty-facing) channel gets its answer in the
+            # platform home channel — draft internals and status chatter never
+            # land in front of the supplier.  Fail-open: any lookup/send
+            # problem falls back to normal in-channel delivery.
+            if response and _operator_unaddressed_in_quiet(
+                event, source, _load_gateway_config(),
+            ):
+                _home = self.config.get_home_channel(source.platform) if self.config else None
+                _home_adapter = self._adapter_for_source(source)
+                if _home and _home.chat_id and _home_adapter:
+                    try:
+                        await _home_adapter.send(
+                            _home.chat_id,
+                            f"<#{source.chat_id}> operator bookkeeping:\n{response}",
+                        )
+                        logger.info(
+                            "Routed operator bookkeeping answer from %s to home channel %s",
+                            source.chat_id, _home.chat_id,
+                        )
+                        return None
+                    except Exception as _home_err:
+                        logger.warning(
+                            "Home-channel reroute failed for %s: %s — falling back to in-channel delivery",
+                            source.chat_id, _home_err,
+                        )
 
             return response
             
@@ -28232,6 +28349,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
+        suppress_streaming: bool = False,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -28252,6 +28370,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
+                suppress_streaming=suppress_streaming,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -28265,6 +28384,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
+                suppress_streaming=suppress_streaming,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -28408,6 +28528,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
+        suppress_streaming: bool = False,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -28717,6 +28838,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
             persist_user_display_kind=persist_user_display_kind,
+            suppress_streaming=suppress_streaming,
         )
         turn_runner = TurnRunner(self, turn_ctx)
         # Callback invoked by agent on tool lifecycle events — extracted to
@@ -29946,6 +30068,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message=next_message,
                     context_prompt=context_prompt,
                     history=updated_history,
+                    suppress_streaming=suppress_streaming,
                     source=next_source,
                     session_id=session_id,
                     session_key=next_session_key,

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -37,6 +37,10 @@ class TurnContext:
     source: Any = None
     _run_still_current: Callable[[], bool] = None  # type: ignore[assignment]
     _live_status_adapter: Any = None
+    # When True, the turn runs without the stream consumer (no streamed
+    # preview into the channel).  Set for operator-bookkeeping turns in
+    # quiet channels, whose answers are rerouted to the home channel.
+    suppress_streaming: bool = False
     _live_status_mode: str = "off"
     _thinking_enabled: bool = False
     progress_mode: str = "off"


### PR DESCRIPTION
Completes the supplier-desk surface family:

- **Operator bookkeeping reroute**: an operator's unaddressed message in a quiet (counterparty-facing) channel gets its answer in the platform home channel; suppress_streaming is threaded through the _run_agent chain so nothing streams in-channel either. Fail-open to in-channel on any lookup/send problem.
- **Silent queue**: follow-ups in quiet channels queue without interrupting the live turn and without the 'Interrupting current task' ack reaching the supplier.
- **gateway.jobs_channel**: background-job lifecycle notices route to the jobs channel for internal chats.
- **gateway.desk_log_channel**: self-improvement/bg-review traces route to the desk-log channel (and are fully suppressed in quiet channels).

Tests: 44/44 green (supplier surfaces, silence tokens, never-silent ack). Deployed config: #ito-approvals (SLACK_APPROVALS_CHANNEL), #ito-jobs, #ito-desk-log wired in the ito profile. Rollback: revert merge; remove the channel keys and restart ai.hermes.gateway-ito.